### PR TITLE
added warning about storage events

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,7 +610,7 @@ post.save(function(err, id) {
 
 ##### Storage events
 
-There are eight events that can be called during operations on collections: `beforesave`, `beforeinsert`, `beforeupdate`, `beforeremove`, `aftersave`, `afterinsert`, `afterupdate`, `afterremove`. Their names are self explanatory. We can hook into process of saving, inserting, updating and removing of a document.
+There are eight events that can be called during operations on collections: `beforesave`, `beforeinsert`, `beforeupdate`, `beforeremove`, `aftersave`, `afterinsert`, `afterupdate`, `afterremove`. Their names are self explanatory. We can hook into process of saving, inserting, updating and removing of a document.  NOTE: these hooks are into the save() and remove() events of the Class - they will not be called on direct manipulations of the underlying collections (i.e. Posts.remove(id)).
 
 ```js
 Post = Astro.Class({


### PR DESCRIPTION
For those comparing against things like collection-hooks, I thought it would be helpful to highlight that the events are only relative to Class operations and not operations on the underlying collections.