### PR TITLE
made 'date' type cast always return a value

### DIFF
--- a/lib/modules/types/init_module.js
+++ b/lib/modules/types/init_module.js
@@ -45,6 +45,8 @@ typesOnInitModule = function() {
         var date = Date.parse(value);
         if (!_.isNaN(date)) {
           return new Date(date);
+        } else {
+          return null;
         }
       } else if (_.isNumber(value)) {
         return new Date(value);


### PR DESCRIPTION
'date' type cast wasn't returning a value when non-date strings were passed in.

Believe returning null makes more sense than undefined for most use cases.  For example, when parsing a form to edit an object, a blank date should override a previously set one.  Undefined values are ignored by set(), thus null is needed.