### PR TITLE
Check amount of fields only for non child classes

### DIFF
--- a/lib/modules/fields/init_class.js
+++ b/lib/modules/fields/init_class.js
@@ -6,7 +6,7 @@ var checks = {
     }
 
     // Check if the amount of fields is at least 1.
-    if (_.size(schemaDefinition.fields) === 0) {
+    if (_.size(schemaDefinition.fields) === 0 && !this.getParent()) {
       throw new Error('At least one field has to be defined');
     }
   },


### PR DESCRIPTION
Allow classes, which have a parent class to have no extra fields.
See #35