### PR TITLE
Let types specify a display format

### DIFF
--- a/lib/modules/types/global.js
+++ b/lib/modules/types/global.js
@@ -1,1 +1,2 @@
 Astro.types = {};
+Astro.displays = {};

--- a/lib/modules/types/init_module.js
+++ b/lib/modules/types/init_module.js
@@ -55,4 +55,47 @@ typesOnInitModule = function() {
       }
     }
   });
+
+  _.extend(Astro.BaseClass.prototype, {
+    getDisplay: function(fieldNameOrPattern) {
+      var doc = this;
+      var Class = doc.constructor;
+      var retval;
+
+      if (arguments.length === 0) {
+        return doc.getDisplay(Astro.utils.fields.getAllFieldsNames(Class));
+      } else if (arguments.length === 1) {
+         if (_.isArray(fieldNameOrPattern)) {
+           retval = {};
+
+           _.each(fieldNameOrPattern, function(name) {
+             values[name] = doc.getDisplay(name);
+           });
+           return retval;
+         } else if (_.isString(fieldNameOrPattern)) {
+           if (fieldNameOrPattern.indexOf('$') === -1) {
+             var fieldDefinition = Astro.utils.fields.getDefinition(Class, fieldNameOrPattern);
+             var value = doc.get(fieldNameOrPattern);
+
+             if (fieldDefinition) {
+               return Astro.utils.types.displayValue(fieldDefinition.type, value);
+             } else {
+               return value;
+             }
+           } else {
+             var fieldNames = Astro.utils.fields.getFieldsNamesFromPattern(
+               doc,
+               fieldNameOrPattern
+             );
+             retval = {};
+
+             _.each(names, function(name) {
+               values[name] = doc.getDisplay(name);
+             });
+             return retval;
+           }
+         }
+       }
+     }
+  });
 };

--- a/lib/modules/types/init_module.js
+++ b/lib/modules/types/init_module.js
@@ -45,6 +45,8 @@ typesOnInitModule = function() {
         var date = Date.parse(value);
         if (!_.isNaN(date)) {
           return new Date(date);
+        } else {
+          return null;
         }
       } else if (_.isNumber(value)) {
         return new Date(value);

--- a/lib/modules/types/init_module.js
+++ b/lib/modules/types/init_module.js
@@ -57,7 +57,7 @@ typesOnInitModule = function() {
   });
 
   _.extend(Astro.BaseClass.prototype, {
-    getDisplay: function(fieldNameOrPattern) {
+    getDisplay: function(fieldNameOrPattern, params) {
       var doc = this;
       var Class = doc.constructor;
       var retval;
@@ -78,7 +78,7 @@ typesOnInitModule = function() {
              var value = doc.get(fieldNameOrPattern);
 
              if (fieldDefinition) {
-               return Astro.utils.types.displayValue(fieldDefinition.type, value);
+               return Astro.utils.types.displayValue(fieldDefinition.type, value, params);
              } else {
                return value;
              }

--- a/lib/modules/types/type.js
+++ b/lib/modules/types/type.js
@@ -25,5 +25,13 @@ Astro.createType = function(typeDefinition) {
     throw new Error('The "cast" attribute has to be a function');
   }
 
+  // Check if the "display" attribute is function (if it's present).
+  if (typeDefinition.display && !_.isFunction(typeDefinition.cast)) {
+    throw new Error('The "display" attribute has to be a function');
+  }
+
   Astro.types[typeDefinition.name] = typeDefinition.cast;
+  if (typeDefinition.display)
+   Astro.displays[typeDefinition.name] = typeDefinition.display;
+
 };

--- a/lib/modules/types/utils.js
+++ b/lib/modules/types/utils.js
@@ -8,3 +8,12 @@ Astro.utils.types.castValue = function(type, value) {
 
   return value;
 };
+
+Astro.utils.types.displayValue = function(type, value) {
+  // We only format value if the type was provided.
+  if (!_.isNull(type) && Astro.displays[type] && !_.isUndefined(value) && !_.isNull(value)) {
+    value = Astro.displays[type](value);
+  }
+
+  return value;
+};

--- a/lib/modules/types/utils.js
+++ b/lib/modules/types/utils.js
@@ -9,10 +9,10 @@ Astro.utils.types.castValue = function(type, value) {
   return value;
 };
 
-Astro.utils.types.displayValue = function(type, value) {
+Astro.utils.types.displayValue = function(type, value, params) {
   // We only format value if the type was provided.
   if (!_.isNull(type) && Astro.displays[type] && !_.isUndefined(value) && !_.isNull(value)) {
-    value = Astro.displays[type](value);
+    value = Astro.displays[type](value,params);
   }
 
   return value;


### PR DESCRIPTION
It can be helpful (think forms) to have display formats associated with each type.  I could do this with a behavior, but it seemed better to integrate it with types so that you only need to define the formatter function once (in the type definition).

Not sure if there's a simpler way to implement this, but here it is, if you're interested.

To the developer, the changes are:

Inside type definition, can add an attribute 'display':

    Astro.createType({
        name: 'currency',
        cast: ...
        display: function(value) { return accounting.formatMoney(value); }
    });

If I have a field 'dollars' with type 'currency', I can then simply do:

    obj.getDisplay('dollars') 

to get the properly formatted version.  `getDisplay` also supports requesting via the other fieldOrPattern styles.

You can also take a parameter argument in `display()` and pass it in `getDisplay()`, for example to specify a number of decimal points:

    obj.getDisplay('dollars',2);

If you like it, I can update the documentation for types, as well.