### PR TITLE
Fixed "check" dependency

### DIFF
--- a/package.js
+++ b/package.js
@@ -12,6 +12,7 @@ Package.onUse(function(api) {
   api.use('minimongo');
   api.use('underscore');
   api.use('ejson');
+  api.use('check');
 
   api.addFiles([
     'lib/modules/core/global.js',


### PR DESCRIPTION
Missing `check` dependency throws error when `jagi:astronomy@1.0.0-rc.1` is used inside custom package.
``` bash
ReferenceError: Match is not defined
W20150918-13:01:49.705(6)? (STDERR)     at Schema.checkSchemaDefinition (packages/jagi_astronomy/packages/jagi_astronomy.js:344:8)
W20150918-13:01:49.705(6)? (STDERR)     at new Schema (packages/jagi_astronomy/packages/jagi_astronomy.js:356:25)
W20150918-13:01:49.705(6)? (STDERR)     at Object.Astro.createClass.Astro.Class (packages/jagi_astronomy/packages/jagi_astronomy.js:477:18)
W20150918-13:01:49.706(6)? (STDERR)     at Package (packages/ribbedcrown:astro-test/lib/model.js:1:1)
```