### PR TITLE
adding tests and fix for throwing an exception when nested model not defined

### DIFF
--- a/lib/modules/fields/types/array_field.js
+++ b/lib/modules/fields/types/array_field.js
@@ -14,10 +14,11 @@ Astro.createType({
       }
 
       var Class = Astro.getClass(definition.nested);
-      if (Class) {
-        this.class = Class;
-        return;
+      if (!Class) {
+        throw new Error('The nested class for [' + definition.name + '] does not exist');
       }
+      this.class = Class;
+      return;
     } else if (_.isObject(definition.nested)) {
       this.class = Astro.Class(definition.nested);
     } else {

--- a/lib/modules/fields/types/object_field.js
+++ b/lib/modules/fields/types/object_field.js
@@ -7,10 +7,11 @@ Astro.createType({
 
     if (_.isString(definition.nested)) {
       var Class = Astro.getClass(definition.nested);
-      if (Class) {
-        this.class = Class;
-        return;
+      if (!Class) {
+        throw new Error('The nested class for [' + definition.name + '] does not exist');
       }
+      this.class = Class;
+      return;
     } else if (_.isObject(definition.nested)) {
       this.class = Astro.Class(definition.nested);
       return;

--- a/test/fields/fields_casting.js
+++ b/test/fields/fields_casting.js
@@ -119,4 +119,29 @@ Tinytest.add('Fields - Casting', function(test) {
   test.instanceOf(cast.arrayNested[0], NestedCast,
     'The casted value of the "arrayNested.0" field is not correct'
   );
+
+  test.throws(function() {
+    var InvalidNested = Astro.createClass({
+      name: 'InvalidNested',
+      fields: {
+        'invalid': {
+          type: 'object',
+          nested: 'NonExistentClass'
+        }
+      }
+    });
+  }, 'The nested class for [invalid] does not exist');
+
+  test.throws(function() {
+    var InvalidArrayNested = Astro.createClass({
+      name: 'InvalidArrayNested',
+      fields: {
+        'invalid': {
+          type: 'array',
+          nested: 'NonExistentClass'
+        }
+      }
+    });
+  }, 'The nested class for [invalid] does not exist');
+
 });


### PR DESCRIPTION
Might be useful to throw an exception to developer when the `field.nested` class does not exist. 