### PR TITLE
handling some edge cases

### DIFF
--- a/lib/modules/fields/types/number_field.js
+++ b/lib/modules/fields/types/number_field.js
@@ -7,6 +7,14 @@ Astro.createType({
     return !_.isNumber(value);
   },
   cast: function(value) {
+    if (_.isString(value)) {
+      if (value === '') {
+        return null;
+      }
+      if (!/^[\d\-\.]+$/.test(value)) {
+        return NaN;
+      }
+    }
     return Number(value);
   }
 });

--- a/test/fields/fields_casting.js
+++ b/test/fields/fields_casting.js
@@ -50,6 +50,16 @@ Tinytest.add('Fields - Casting', function(test) {
     'The casted value of the "number" field is not correct'
   );
 
+  cast.set('number', '');
+  test.equal(cast.number, null,
+    'The casted value of empty string for "number" field is not correct'
+  );
+
+  cast.set('number', '1e1');
+  test.equal(cast.number, NaN,
+    'The casted value of scientific notation for "number" field is not correct'
+  );
+
   cast.set('boolean', '');
   test.isFalse(cast.boolean,
     'The casted value of the "boolean" field is not correct'


### PR DESCRIPTION
Hi, ran into a couple of edge cases, that may need to be addressed: 

1. If empty string is cast, it gets set to 0. It should probably be `null`
1. If a string like `1e1` is passed, it gets cast to 10 as Number converts it to scientific notation. This should probably be NaN.