### PR TITLE
adds sorting to nested documents

### DIFF
--- a/lib/modules/fields/modifiers.js
+++ b/lib/modules/fields/modifiers.js
@@ -53,22 +53,23 @@ proto._addModifier = function(modifierName, fieldName, fieldValue) {
       return true;
     },
     $push: function() {
+      var field = doc.constructor.getField(fieldName);
       // First, we check whether there is already the $push modifier for the
       // given field name.
-      if (_.has(doc._modifiers.$push, fieldName)) {
-        if (_.has(doc._modifiers.$push[fieldName], '$each')) {
-          doc._modifiers.$push[fieldName].$each.push(fieldValue);
-        } else {
-          doc._modifiers.$push[fieldName] = {
-            $each: [
-              doc._modifiers.$push[fieldName],
-              fieldValue
-            ]
-          };
-        }
-      } else {
-        doc._modifiers.$push[fieldName] = fieldValue;
+      var oldSetting = doc._modifiers.$push[fieldName];
+      var newSetting = doc._modifiers.$push[fieldName] = oldSetting || {
+        $each: []
+      };
+
+      if(!oldSetting && field.sort) {
+        newSetting.$sort = field.sort;
+        // Meteor requires $slice in order to use $sort, but we don't want to slice it.
+        // So we use 'Minimum value for an object of type long long int (in cpp)'
+        // @see https://forums.meteor.com/t/push-and-sort-a-couple-separated-by-slice/13699?u=zvictor
+        newSetting.$slice = -9223372036854775807;
       }
+
+      newSetting.$each.push(fieldValue);
       return true;
     },
     $inc: function() {

--- a/lib/modules/fields/types/array_field.js
+++ b/lib/modules/fields/types/array_field.js
@@ -3,6 +3,9 @@ Astro.createType({
   constructor: function ArrayField(definition) {
     Astro.BaseField.apply(this, arguments);
 
+    this.sort = _.isUndefined(definition.sort) ?
+      false : definition.sort;
+
     this.field = null;
     this.class = null;
 


### PR DESCRIPTION
Allows sorting of nested documents.
The documents are sorted when they are pushed.

Example:

```js
Post = Astro.Class({
  name: 'Post',
  collection: Posts,
  fields: {
    'comments': {
      type: 'array',
      sort: {
        // sorts comments by date of creation
        createdAt: 1
      },
      nested: 'Comment',
      default: function() {
        return {};
      }
    }
  }
});
```