### PR TITLE
Updated .versions to match package version 2.0.0-rc.1

### DIFF
--- a/.versions
+++ b/.versions
@@ -21,15 +21,10 @@ html-tools@1.0.5
 htmljs@1.0.5
 id-map@1.0.4
 insecure@1.0.4
-jagi:astronomy@1.2.0
-jagi:astronomy-simple-validators@1.0.2
-jagi:astronomy-slug-behavior@1.2.0
-jagi:astronomy-softremove-behavior@1.0.0
-jagi:astronomy-timestamp-behavior@1.1.0
-jagi:astronomy-validators@1.1.0
+jagi:astronomy@2.0.0-rc.1
 jagi:reactive-map@2.0.0
 jquery@1.11.4
-local-test:jagi:astronomy@1.2.0
+local-test:jagi:astronomy@2.0.0-rc.1
 logging@1.0.8
 meteor@1.1.10
 minimongo@1.0.10


### PR DESCRIPTION
When including 2.0.0-rc.1 in a meteor app, a version conflict arises
Conflict: Constraint jagi:astronomy@2.0.0-rc.1 is not satisfied by jagi:astronomy 1.2.10.
Constraints on package "jagi:astronomy":

Updating the package .versions to remove the packages no longer required and updating
the package version for astronomy to 2.0.0-rc.1 allows the package to be installed in
meteor apps without conflict.