### PR TITLE
fix for cannot update x and x at the same time

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -4,16 +4,18 @@ import throwParseError from './utils/throw_parse_error.js';
 import warn from './utils/warn.js';
 import wrapCallback from './utils/wrap_callback.js';
 import hasMeteorMethod from './utils/has_meteor_method.js';
+import removeUndefined from './utils/remove_undefined.js';
 
 const Utils = {
-	core: {
-		cloneDefinition: cloneDefinition,
-		overrideMethod: overrideMethod,
-		throwParseError: throwParseError,
-		warn: warn,
-		wrapCallback: wrapCallback,
-		hasMeteorMethod: hasMeteorMethod
-	}
+    core: {
+        cloneDefinition: cloneDefinition,
+        overrideMethod: overrideMethod,
+        throwParseError: throwParseError,
+        warn: warn,
+        wrapCallback: wrapCallback,
+        hasMeteorMethod: hasMeteorMethod,
+        removeUndefined: removeUndefined
+    }
 };
 
 export default Utils;

--- a/lib/core/utils/remove_undefined.js
+++ b/lib/core/utils/remove_undefined.js
@@ -1,0 +1,11 @@
+function removeUndefined(obj) {
+  return _.transform(obj, function (o, v, k) {
+    if (_.isPlainObject(v)) {
+      o[k] = removeUndefined(v);
+    } else if (!_.isUndefined(v)) {
+      o[k] = v;
+    }
+  });
+};
+
+export default removeUndefined;

--- a/lib/modules/fields/utils/set_one.js
+++ b/lib/modules/fields/utils/set_one.js
@@ -1,5 +1,6 @@
 import traverse from '../utils/traverse.js';
 import warn from '../../../core/utils/warn.js';
+import removeUndefined from '../../../core/utils/remove_undefined.js';
 
 function setOne(doc, fieldPattern, fieldValue) {
 	return traverse(
@@ -15,7 +16,19 @@ function setOne(doc, fieldPattern, fieldValue) {
 				return;
 			}
 
-			nestedDoc[nestedFieldName] = fieldValue;
+			// If the document is new, don't allow the user to set properties
+			// as undefined, as they will be turned into "null" values when inserted
+			// into the DB. Then, since they're undefined on the model, and null in the db,
+			// getModified() will return false positives.
+			if (doc._isNew) {
+				if (_.isPlainObject(fieldValue)) {
+					nestedDoc[nestedFieldName] = removeUndefined(fieldValue);
+				} else if (!_.isUndefined(fieldValue)) {
+					nestedDoc[nestedFieldName] = fieldValue;
+				}
+			} else {
+				nestedDoc[nestedFieldName] = fieldValue;
+			}
 		}
 	);
 };

--- a/lib/modules/storage/utils/document_update.js
+++ b/lib/modules/storage/utils/document_update.js
@@ -1,4 +1,5 @@
 import isEnvironment from '../../../core/utils/is_environment.js';
+import removeUndefined from '../../../core/utils/remove_undefined.js';
 import castNested from '../../fields/utils/cast_nested.js';
 import triggerBeforeSave from './trigger_before_save.js';
 import triggerBeforeUpdate from './trigger_before_update.js';
@@ -60,6 +61,11 @@ function documentUpdate(args = {}) {
   }, getModifier({
     doc
   }));
+
+  // After we're done $unset-ing undefined values in the DB,
+  // remove them from the model so that they don't trigger
+  // false positives in getModified().
+  doc.set(removeUndefined(doc.raw()));
 
   // Trigger after events.
   triggerAfterUpdate(doc, trusted);

--- a/lib/modules/storage/utils/get_modifier.js
+++ b/lib/modules/storage/utils/get_modifier.js
@@ -132,7 +132,8 @@ function getModifier(options) {
     // Return only non empty modifiers.
     let modifier = {};
     if (_.size($set)) {
-      modifier.$set = $set;
+      // If we are unsetting, we cannot set
+      modifier.$set = _.omit($set, Object.keys($unset));
     }
     if (_.size($unset)) {
       modifier.$unset = $unset;

--- a/lib/modules/storage/utils/get_modifier.js
+++ b/lib/modules/storage/utils/get_modifier.js
@@ -1,3 +1,4 @@
+import removeUndefined from '../../../core/utils/remove_undefined.js';
 import rawAll from '../../fields/utils/raw_all.js';
 
 function getModifier(options) {
@@ -132,8 +133,12 @@ function getModifier(options) {
     // Return only non empty modifiers.
     let modifier = {};
     if (_.size($set)) {
-      // If we are unsetting, we cannot set
-      modifier.$set = _.omit($set, Object.keys($unset));
+      // never set undefined values, because mongo turns them into "null" values,
+      // which is not desired.
+      $set = removeUndefined($set);
+      if (_.size($set)) {
+        modifier.$set = $set;
+      }
     }
     if (_.size($unset)) {
       modifier.$unset = $unset;


### PR DESCRIPTION
If something is set then unset, or set to undefined, a modifier like this ends up being built:

```js
$set = { 'securitySchemes.oauth2.scopes': undefined }
$unset = { 'securitySchemes.oauth2.scopes': '' }
```

Which leads to this error:

```
"Cannot update 'securitySchemes.oauth2.scopes' and 'securitySchemes.oauth2.scopes' at the same time"
```

Wether or not this fix covers all possible edge cases I'm not sure? Unfortunately I'm not yet familiar enough with the Astronomy internals - just getting into it!