### PR TITLE
Fix validation error when validate is called before a document has been saved

### DIFF
--- a/lib/modules/validators/utils/document_validate.js
+++ b/lib/modules/validators/utils/document_validate.js
@@ -85,6 +85,11 @@ function documentValidate(options = {}) {
       return;
     }
 
+    // We do not validate the _id if the document is new.
+    if (field.name === '_id' && doc._isNew) {
+      return;
+    }
+
     // Get value of the field.
     let value = doc.get(name);
 


### PR DESCRIPTION
In Astronomy 1.2.x it was possible to call `validate` even before the document had been saved. If the call returned false, the errors could be evaluated. 

In Astronomy 2.x, a call to `validate` fails if the document has not been saved before. This pull request fixes this problem.