### PR TITLE
Document id validation

### DIFF
--- a/lib/modules/storage/class_static_methods/update.js
+++ b/lib/modules/storage/class_static_methods/update.js
@@ -47,7 +47,7 @@ function update(selector, modifier, options, callback) {
     }
 
   }
-  // If we can just remove a document without calling the meteor method. We may
+  // If we can just update a document without calling the meteor method. We may
   // be on the server or the collection may be local.
   else {
 

--- a/lib/modules/storage/hooks/apply_definition.js
+++ b/lib/modules/storage/hooks/apply_definition.js
@@ -37,8 +37,11 @@ function onApplyDefinition(Class, parsedDefinition, className) {
         _id: {
           name: '_id',
           type: String,
-          // Make a field required only on the server.
-          optional: !Meteor.isServer
+          // _id is optional, but has to be a string if it is not empty
+          optional: true,
+          validators: [{
+            type: 'string'
+          }]
         }
       },
       // Add storage events.

--- a/test/modules/validators/validate.js
+++ b/test/modules/validators/validate.js
@@ -1,6 +1,10 @@
 Tinytest.add('Modules - Validators - Validate', function(test) {
+
+  let ValidatorCollection = new Mongo.Collection("ClassValidators");
+
   let ClassValidator = Astro.Class.create({
     name: 'ClassValidator',
+    collection: ValidatorCollection,
     fields: {
       nameA: {
         type: String,
@@ -102,6 +106,34 @@ Tinytest.add('Modules - Validators - Validate', function(test) {
     test.equal(
       errors[1].name, 'nameB',
       'Wrong validation error'
+    );
+  }
+  
+  // Check that _id is properly validated when it is provided
+  docValidator._id = {};
+  try {
+    docValidator.validate();
+  }
+  catch (e) {
+    test.instanceOf(
+      e, Meteor.Error,
+      'Should throw Meteor.Error'
+    );
+
+    test.equal(
+      e.error, Astro.ValidationError.ERROR_CODE,
+      'Should throw validation error'
+    );
+    
+    test.equal(
+      e.details.length, 1,
+      'Should throw one error'
+    );
+
+    let error = e.details[0];
+    test.equal(
+      error.name, '_id',
+      'has to be a string'
     );
   }
 });


### PR DESCRIPTION
Another version: In Astronomy 1.2.x it was possible to call validate even before the document had been saved. If the call returned false, the errors could be evaluated.

In Astronomy 2.x, a call to validate fails if the document has not been saved before. This pull request fixes this problem.
