### PR TITLE
Fix client validation for classes without assigned collection

### DIFF
--- a/lib/modules/storage/utils/call_meteor_method.js
+++ b/lib/modules/storage/utils/call_meteor_method.js
@@ -2,10 +2,10 @@ function callMeteorMethod(
   Class, methodName, methodArgs, methodOptions, wrappedCallback
 ) {
   const Collection = Class.getCollection();
-  if (!Collection) {
-    return;
+  let connection = Collection && Collection._connection;
+  if (!connection && (!Collection || !Collection._name)) {
+    connection = Meteor.connection;
   }
-  const connection = Collection._connection;
 
   return connection.apply(
     methodName, methodArgs, methodOptions, wrappedCallback

--- a/package.js
+++ b/package.js
@@ -60,7 +60,8 @@ Package.onTest(function(api) {
   api.addFiles([
     'test/modules/validators/create.js',
     'test/modules/validators/apply.js',
-    'test/modules/validators/validate.js'
+    'test/modules/validators/validate.js',
+    'test/modules/validators/validate_callback.js'
   ], ['client', 'server']);
   // Modules - Storage.
   api.addFiles([

--- a/test/modules/validators/validate_callback.js
+++ b/test/modules/validators/validate_callback.js
@@ -1,0 +1,20 @@
+Tinytest.addAsync('Modules - Validators - ValidateWithCallback', function(test, onComplete) {
+    let ClassValidatorAsync = Astro.Class.create({
+        name: 'ClassValidatorAsync',
+        fields: {
+            nameA: {
+                type: String
+            }
+        }
+    });
+
+    let docValidatorAsync = new ClassValidatorAsync();
+
+    docValidatorAsync.nameA = {};
+
+    // Validate with callback
+    docValidatorAsync.validate({ fields: 'nameA' }, function(validationError) {
+        test.isNotUndefined(validationError, 'Document not validated properly');
+        onComplete();
+    });
+});


### PR DESCRIPTION
In https://github.com/jagi/meteor-astronomy/commit/53f7338f86c329adf144d1a3f31e19b76467d54a a new method `callMeteorMethod` was introduced for making server calls. 

Before this change, calls to `validate` for class objects without collections were executed successfully, because if no collection existed, a fallback to `Meteor.connection` was implemented. With the introduction of `callMeteorMethod`, this fallback got lost and so calls to `validate` for classes without a collection were not possible any longer.

This PR fixes this problem.
