### PR TITLE
Support dynamic resolving optional property for fields

### DIFF
--- a/lib/modules/fields/field.js
+++ b/lib/modules/fields/field.js
@@ -25,9 +25,16 @@ class Field {
     return this.default;
   }
 
+  getOptional(doc) {
+    if (_.isFunction(this.optional)) {
+      return this.optional(doc);
+    }
+    return this.optional;
+  }
+
   validate(args) {
     // If a field is not optional (required) then it has to have value.
-    if (!this.optional) {
+    if (!this.getOptional(args.doc)) {
       Validators.required(args);
     }
   }

--- a/lib/modules/validators/utils/document_validate.js
+++ b/lib/modules/validators/utils/document_validate.js
@@ -100,7 +100,7 @@ function documentValidate(options = {}) {
     let value = doc.get(name);
 
     // If a field is optional and value is undefined then we do not validate.
-    if (field.optional && _.isNil(value)) {
+    if (field.getOptional(doc) && _.isNil(value)) {
       return;
     }
 

--- a/package.js
+++ b/package.js
@@ -39,7 +39,7 @@ Package.onTest(function(api) {
     'insecure',
     'mongo',
     'ejson',
-    'jagi:astronomy@2.0.0'
+    'jagi:astronomy@2.0.1'
   ], ['client', 'server']);
 
   api.addFiles('test/utils.js', ['client', 'server']);
@@ -101,7 +101,8 @@ Package.onTest(function(api) {
     'test/modules/fields/default.js',
     'test/modules/fields/set.js',
     'test/modules/fields/get.js',
-    'test/modules/fields/raw.js'
+    'test/modules/fields/raw.js',
+    'test/modules/fields/optional.js'
   ], ['client', 'server']);
   // Modules - Indexes.
   api.addFiles([

--- a/test/modules/fields/optional.js
+++ b/test/modules/fields/optional.js
@@ -1,0 +1,34 @@
+import _ from 'lodash';
+
+Tinytest.add('Fields - Modules - Optional', function(test) {
+  reset();
+
+  // Define simple class to work with.
+  let Default = Astro.Class.create({
+    name: 'Default',
+    fields: {
+      firstField: {
+        type: String,
+        default: ''
+      },
+      secondField: {
+        type: String,
+        optional: function(doc) {
+          return this.firstField.length;
+        }
+      }
+    }
+  });
+
+  let doc = new Default();
+
+  test.equal(Default.getField('firstField').optional, 
+     false,
+    'optional for "firstField" should return false'
+  );
+
+  test.equal(_.isFunction(Default.getField('secondField').optional), 
+     true,
+    'optional for field "secondField" should be a function'
+  );
+});


### PR DESCRIPTION
Consider the following use case:

I have a class with a field that should be optional when another field does not contain a special value or when the document is inserted for the first time. Example:

``` javascript
ClassWithDynamicOptionalField = Class.create({
    name: 'ClassWithDynamicOptionalField',
    collection: sampleCollection,
    fields: {
      nameA: {
        type: String
      },
      nameB: {
        type: String,
        optional: function(doc) {
          return doc.nameA !== 'specialValue';
          // other possible use case
          // return doc._isNew;
        }
      }
    }
  });
```

This MR contains the necessary changes and adds test cases for this.

@jagi Can we get this in 2.1?
