### PR TITLE
Add missing import statement

### DIFF
--- a/lib/modules/storage/utils/class_update.js
+++ b/lib/modules/storage/utils/class_update.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import AstroClass from '../../../core/class.js';
 import throwIfSelectorIsNotId from './throw_if_selector_is_not_id.js';
 import documentUpdate from './document_update.js';


### PR DESCRIPTION
Fixes the following error:

`Exception while invoking method '/Astronomy/update' ReferenceError: _ is not defined
at classUpdate (packages/jagi:astronomy/lib/modules/storage/utils/class_update.js:38:33)
at [object Object].update (packages/jagi:astronomy/lib/modules/storage/meteor_methods/update.js:4:10)
at maybeAuditArgumentChecks (packages/ddp-server/livedata_server.js:1704:12)`
