### PR TITLE
Equal and Not Equal validators compare dates properly

### DIFF
--- a/lib/modules/validators/validators/comparison/equal.js
+++ b/lib/modules/validators/validators/comparison/equal.js
@@ -3,10 +3,7 @@ import Validator from '../../validator.js';
 Validator.create({
   name: 'equal',
   isValid({ value, param }) {
-    if (value instanceof Date && param instanceof Date) {
-      return value.getTime() === param.getTime();
-    }
-    return value === param;
+    return EJSON.equals(value, param);
   },
   resolveError({ name, param }) {
     return `"${name}" should be equal ${param}`;

--- a/lib/modules/validators/validators/comparison/equal.js
+++ b/lib/modules/validators/validators/comparison/equal.js
@@ -3,6 +3,9 @@ import Validator from '../../validator.js';
 Validator.create({
   name: 'equal',
   isValid({ value, param }) {
+    if (value instanceof Date && param instanceof Date) {
+      return value.getTime() === param.getTime();
+    }
     return value === param;
   },
   resolveError({ name, param }) {

--- a/lib/modules/validators/validators/comparison/not_equal.js
+++ b/lib/modules/validators/validators/comparison/not_equal.js
@@ -3,6 +3,9 @@ import Validator from '../../validator.js';
 Validator.create({
   name: 'notEqual',
   isValid({ value, param }) {
+    if (value instanceof Date && param instanceof Date) {
+      return value.getTime() !== param.getTime();
+    }
     return value !== param;
   },
   resolveError({ name, param }) {

--- a/lib/modules/validators/validators/comparison/not_equal.js
+++ b/lib/modules/validators/validators/comparison/not_equal.js
@@ -3,10 +3,7 @@ import Validator from '../../validator.js';
 Validator.create({
   name: 'notEqual',
   isValid({ value, param }) {
-    if (value instanceof Date && param instanceof Date) {
-      return value.getTime() !== param.getTime();
-    }
-    return value !== param;
+    return !EJSON.equals(value, param);
   },
   resolveError({ name, param }) {
     return `"${name}" should not to be equal ${param}`;


### PR DESCRIPTION
If both value and param are instances of dates, to compare equality we need to call `.getTime()`: http://stackoverflow.com/a/493018/1389202
