### PR TITLE
send fields on insert and update

### DIFF
--- a/lib/modules/storage/class_prototype_methods/save.js
+++ b/lib/modules/storage/class_prototype_methods/save.js
@@ -40,6 +40,7 @@ function save(args = {}, callback) {
       className: Class.getName(),
       stopOnFirstError,
       simulation,
+      fields,
     };
     // Inserting.
     if (inserting) {
@@ -59,7 +60,6 @@ function save(args = {}, callback) {
           doc
         }),
         options: {},
-        fields
       });
     }
 
@@ -95,6 +95,7 @@ function save(args = {}, callback) {
       doc,
       stopOnFirstError,
       simulation,
+      fields,
       trusted: true
     };
     if (inserting) {
@@ -105,7 +106,6 @@ function save(args = {}, callback) {
       return result;
     }
     else {
-      methodArgs.fields = fields;
       let result = documentUpdate(methodArgs);
       if (callback) {
         callback(undefined, result);

--- a/lib/modules/storage/class_static_methods/find.js
+++ b/lib/modules/storage/class_static_methods/find.js
@@ -13,6 +13,7 @@ function createMethod(methodName) {
     _.defaults(options, {
       defaults: true,
       children: true,
+      safe: true,
     });
 
     // Modify selector and options using the "beforeFind" event handlers.

--- a/lib/modules/storage/utils/document_insert.js
+++ b/lib/modules/storage/utils/document_insert.js
@@ -36,7 +36,7 @@ function documentInsert(args = {}) {
   }
 
   // Trigger before events.
-  triggerBeforeSave(doc, trusted);
+  triggerBeforeSave(doc, trusted, fields);
   triggerBeforeInsert(doc, trusted);
 
   // Cast nested documents.

--- a/lib/modules/storage/utils/document_update.js
+++ b/lib/modules/storage/utils/document_update.js
@@ -48,8 +48,8 @@ function documentUpdate(args = {}) {
   }
 
   // Trigger before events.
-  triggerBeforeSave(doc, trusted);
-  triggerBeforeUpdate(doc, trusted);
+  triggerBeforeSave(doc, trusted, fields);
+  triggerBeforeUpdate(doc, trusted, fields);
 
   // Cast nested documents.
   castNested({

--- a/lib/modules/storage/utils/trigger_before_save.js
+++ b/lib/modules/storage/utils/trigger_before_save.js
@@ -1,11 +1,12 @@
 import Event from '../../events/event.js';
 
-function triggerBeforeSave(doc, trusted) {
+function triggerBeforeSave(doc, trusted, fields = []) {
 	// Trigger the "beforeSave" event handlers.
 	if (!doc.dispatchEvent(new Event('beforeSave', {
 			cancelable: true,
 			propagates: true,
-			trusted: trusted
+			trusted: trusted,
+			fields,
 		}))) {
 		// If an event was prevented, then we stop here.
 		throw new Meteor.Error('prevented', 'Operation prevented', {

--- a/lib/modules/storage/utils/trigger_before_update.js
+++ b/lib/modules/storage/utils/trigger_before_update.js
@@ -1,11 +1,12 @@
 import Event from '../../events/event.js';
 
-function triggerBeforeUpdate(doc, trusted) {
+function triggerBeforeUpdate(doc, trusted, fields = []) {
 	// Trigger the "beforeUpdate" event handlers.
 	if (!doc.dispatchEvent(new Event('beforeUpdate', {
 			cancelable: true,
 			propagates: true,
-			trusted: trusted
+			trusted: trusted,
+			fields,
 		}))) {
 		// If an event was prevented, then we stop here.
 		throw new Meteor.Error('prevented', 'Operation prevented', {


### PR DESCRIPTION
I guess it was on purpose, but I don’t see why on insert you don’t allow to save only specified fields.
It’s useful when we’re creating a doc in multiple steps.
