### PR TITLE
Adding of .getPublishedFields

### DIFF
--- a/lib/modules/fields/class_static_methods/get_published_fields.js
+++ b/lib/modules/fields/class_static_methods/get_published_fields.js
@@ -1,12 +1,23 @@
 import _ from 'lodash';
+import ObjectField from '../object_field.js';
+import ListField from '../list_field.js';
 
 function getPublishedFields() {
     var publicFields = {};
     _.values(this.schema.fields).forEach((field) => {
-        if (!field.private)
-            publicFields[field.name] = 1;
-    });
+            if (!field.private) {
+                if (field instanceof ObjectField || (field instanceof ListField && field.isClass)) {
+                    Object.keys(field.type.class.getPublishedFields()).forEach((nestedFieldName) => {
+                        publicFields[field.name + "." + nestedFieldName] = 1
+                    })
+                } else
+                    publicFields[field.name] = 1;
+            }
+        }
+    )
+    ;
     return publicFields;
-};
+}
+;
 
 export default getPublishedFields;

--- a/lib/modules/fields/class_static_methods/get_published_fields.js
+++ b/lib/modules/fields/class_static_methods/get_published_fields.js
@@ -1,0 +1,12 @@
+import _ from 'lodash';
+
+function getPublishedFields() {
+    var publicFields = {};
+    _.values(this.schema.fields).forEach((field) => {
+        if (!field.private)
+            publicFields[field.name] = 1;
+    });
+    return publicFields;
+};
+
+export default getPublishedFields;

--- a/lib/modules/fields/field.js
+++ b/lib/modules/fields/field.js
@@ -6,7 +6,8 @@ class Field {
     _.defaults(definition, {
       optional: false,
       immutable: false,
-      transient: false
+      transient: false,
+      private: false
     });
 
     this.name = definition.name;
@@ -16,6 +17,7 @@ class Field {
     this.immutable = definition.immutable;
     this.transient = definition.transient;
     this.resolve = definition.resolve;
+    this.private = definition.private;
   }
 
   getDefault() {

--- a/lib/modules/fields/hooks/init_class.js
+++ b/lib/modules/fields/hooks/init_class.js
@@ -2,6 +2,7 @@
 import getField from '../class_static_methods/get_field.js';
 import getFieldsNames from '../class_static_methods/get_fields_names.js';
 import getFields from '../class_static_methods/get_fields.js';
+import getPublishedFields from '../class_static_methods/get_published_fields.js';
 import getObjectFields from '../class_static_methods/get_object_fields.js';
 import getListFields from '../class_static_methods/get_list_fields.js';
 import getScalarFields from '../class_static_methods/get_scalar_fields.js';
@@ -19,6 +20,7 @@ function onInitClass(Class, className) {
   Class.getField = getField;
   Class.getFieldsNames = getFieldsNames;
   Class.getFields = getFields;
+  Class.getPublishedFields = getPublishedFields;
   Class.getObjectFields = getObjectFields;
   Class.getListFields = getListFields;
   Class.getScalarFields = getScalarFields;


### PR DESCRIPTION
You can now use Class.getPublishedFields() to retrieve the fields that are supposed to be published in a Mongo friendly way:
Example: 

Meteor.publish("UserProfiles", () => {
    return UserProfiles.find({}, {
        fields: UserProfile.getPublishedFields()
    });
});
