### PR TITLE
Properly resolve subclass fields

### DIFF
--- a/lib/modules/storage/utils/transform_to_class.js
+++ b/lib/modules/storage/utils/transform_to_class.js
@@ -3,21 +3,16 @@ import AstroClass from '../../../core/class.js';
 import resolveValues from '../../fields/utils/resolve_values.js';
 
 function transformToClass(className, options = {}) {
-  // Set default options.
-  _.defaults(options, {
-    defaults: true
-  });
-  options.clone = false;
+	// Set default options.
+	_.defaults(options, {
+		defaults: true
+	});
+	options.clone = false;
 
 	return function(rawDoc) {
 		let Class = AstroClass.get(className);
 
 		if (Class) {
-      // Resolve values using the "resolveValue" method if provided.
-      const resolvedDoc = resolveValues({
-        Class,
-        values: rawDoc
-      });
 
 			const typeField = Class.getTypeField();
 			if (typeField) {
@@ -26,6 +21,12 @@ function transformToClass(className, options = {}) {
 					Class = TypeClass;
 				}
 			}
+
+			// Resolve values using the "resolveValue" method if provided.
+			const resolvedDoc = resolveValues({
+				Class,
+				values: rawDoc
+			});
 
 			const doc = new Class(resolvedDoc, options);
 			doc._isNew = false;

--- a/lib/modules/storage/utils/transform_to_class.js
+++ b/lib/modules/storage/utils/transform_to_class.js
@@ -16,7 +16,7 @@ function transformToClass(className, options = {}) {
 
 			const typeField = Class.getTypeField();
 			if (typeField) {
-				const TypeClass = AstroClass.get(resolvedDoc[typeField]);
+				const TypeClass = AstroClass.get(rawDoc[typeField]);
 				if (TypeClass) {
 					Class = TypeClass;
 				}


### PR DESCRIPTION
To properly resolve fields of subclasses, you basically just needed to check for `typeField` before calling `resolveValues()` from within `transformToClass`

This should fix #464 
