### PR TITLE
Pass prefix to children in validator name

### DIFF
--- a/lib/modules/validators/utils/document_validate.js
+++ b/lib/modules/validators/utils/document_validate.js
@@ -75,7 +75,7 @@ function documentValidate(options = {}) {
           documentValidate({
             doc: nestedDoc,
             fields: [nestedName],
-            prefix: name.substr(0, name.lastIndexOf(nestedName)),
+            prefix: prefix + name.substr(0, name.lastIndexOf(nestedName)),
             stopOnFirstError,
             simulation
           });
@@ -146,7 +146,7 @@ function documentValidate(options = {}) {
           documentValidate({
             doc: value,
             fields: value.constructor.getValidationOrder(),
-            prefix: field.name + '.',
+            prefix: prefix + field.name + '.',
             stopOnFirstError
           });
         });
@@ -160,7 +160,7 @@ function documentValidate(options = {}) {
             documentValidate({
               doc: element,
               fields: element.constructor.getValidationOrder(),
-              prefix: field.name + '.' + index + '.',
+              prefix: prefix + field.name + '.' + index + '.',
               stopOnFirstError
             });
           });


### PR DESCRIPTION
This passes the full nested path down through the model structure.  For the following code:

``` javascript
// /server/main.js
import { Meteor } from 'meteor/meteor';
import { Class } from 'meteor/jagi:astronomy';

const Child = Class.create({
  name: 'Child',
  fields: {
    name: {
      type: String,
      validators: [{type: 'equal', param: 'John'}],
    },
    friends: {
      type: [String],
      default: () => [],
    },
    obj: {
      type: Object,
      default: () => {},
      validators: [{type: 'has', param: 'foo'}],
    },
  },
});

const Parent = Class.create({
  name: 'Parent',
  fields: {
    name: {
      type: String,
    },
    child: {
      type: Child,
      optional: true,
    },
    children: {
      type: [Child],
      default: () => [],
    },
  },
});


Meteor.startup(() => {
  let a = new Parent({
    name: 'Bob',
    child: {
      name: 'Steve',
      friends: ['Garry', 3, 'Norbert', 5],
      obj: {},
    },
    children: [{
      name: 'Eric',
      friends: ['Hugo', [3]],
      obj: {
        foo1: 'bar'
      },
    }],
  });
  try {
    a.validate({ stopOnFirstError: false })
  } catch (e) {
    console.log(e);
  }
});
```

You get the following error with full paths for the invalid fields:

```
{ [Error: "child.name" should be equal John [validation-error]]
 error: 'validation-error',
 reason: '"child.name" should be equal John',
 details: 
  [ { className: 'Child',
      type: 'equal',
      name: 'child.name',
      nestedName: 'name',
      value: 'Steve',
      param: 'John',
      message: '"child.name" should be equal John' },
    { className: 'Child',
      type: 'string',
      name: 'child.friends.1',
      nestedName: undefined,
      value: 3,
      param: undefined,
      message: '"child.friends.1" has to be a string' },
    { className: 'Child',
      type: 'has',
      name: 'child.obj',
      nestedName: 'obj',
      value: {},
      param: 'foo',
      message: 'The "child.obj" field does not have the "foo" property' },
    { className: 'Child',
      type: 'equal',
      name: 'children.0.name',
      nestedName: 'name',
      value: 'Eric',
      param: 'John',
      message: '"children.0.name" should be equal John' },
    { className: 'Child',
      type: 'string',
      name: 'children.0.friends.1',
      nestedName: undefined,
      value: [Object],
      param: undefined,
      message: '"children.0.friends.1" has to be a string' },
    { className: 'Child',
      type: 'has',
      name: 'children.0.obj',
      nestedName: 'obj',
      value: [Object],
      param: 'foo',
      message: 'The "children.0.obj" field does not have the "foo" property' } ],
 message: '"child.name" should be equal John [validation-error]',
 errorType: 'Meteor.Error' }
```
