### PR TITLE
Fix typos and logical errors in the documentation

### DIFF
--- a/_includes/v1/key_concepts/inheritance.md
+++ b/_includes/v1/key_concepts/inheritance.md
@@ -69,7 +69,7 @@ var child = new Child();
 child.type; // "Child"
 
 var parent = new Parent();
-child.type; // "Parent"
+parent.type; // "Parent"
 ```
 
 As you can see in both classes Astronomy added the `type` field which stores "Child" and "Parent" strings for `Child` and `Parent` parent classes accordingly. A value of this field will be stored with an instance and when fetching the given document from the collection, the transform function will automatically fetch an instance of proper class.

--- a/_includes/v2/examples.md
+++ b/_includes/v2/examples.md
@@ -1,6 +1,6 @@
 # Examples
 
-The best way to understand Astronomy is learning by an example, that's why there is an example git [repository](https://github.com/jagi/meteor-astronomy-examples) that you can clone and run to see Astronomy in action. The example repository has two branches [ironrouter](https://github.com/jagi/meteor-astronomy-examples/tree/ironrouter) and [flowrouter](https://github.com/jagi/meteor-astronomy-examples/tree/flowrouter) showing usage of Astronomy with two routing packages [IronRouter](https://atmospherejs.com/iron/router) and [FlowRouter](https://atmospherejs.com/meteorhacks/flow-router). I encourage you to take a look at the code to see how integration with form templates is done. ~~You can also take a look at working online example [here](http://astronomy.meteor.com).~~ (Not possible anymore because of termination of the free hosting by MDG)
+The best way to understand Astronomy is learning by an example, that's why there is an example git [repository](https://github.com/jagi/meteor-astronomy-examples/tree/v2) that you can clone and run to see Astronomy in action. The example repository shows usage of Astronomy with [FlowRouter](https://atmospherejs.com/meteorhacks/flow-router). I encourage you to take a look at the code to see how integration with form templates is done.
 
 **The Meteor.users collection**
 

--- a/_includes/v2/key_concepts/events/events_list.md
+++ b/_includes/v2/key_concepts/events/events_list.md
@@ -66,7 +66,7 @@ User.findOne(); // Both events triggered
 
 An event object passed to the `beforeFind` event handler contains two additional properties `selector` and `options`. They are two arguments passed to the `findOne()` or `find()` method. In an event handler you can modify selector or passed options. The **softremove** behavior is using it to limit fetching documents to only those that were not soft removed.
 
-An event object passed to the `beforeFind` event handler contains three additional properties `selector`, `options` and `result`. So, in this event handler you can additionally modify result of a find operation.
+An event object passed to the `afterFind` event handler contains three additional properties `selector`, `options` and `result`. So, in this event handler you can additionally modify result of a find operation.
 
 **EJSON events**
 

--- a/_includes/v2/key_concepts/inheritance.md
+++ b/_includes/v2/key_concepts/inheritance.md
@@ -75,7 +75,7 @@ var child = new Child();
 child.type; // "Child"
 
 var parent = new Parent();
-child.type; // "Parent"
+parent.type; // "Parent"
 ```
 
 As you can see in both classes Astronomy added the `type` field which stores "Child" and "Parent" strings for `Child` and `Parent` parent classes accordingly. A value of this field will be stored with an instance and when fetching the given document from the collection, the transform function will automatically fetch an instance of proper class.

--- a/_includes/v2/security/secured_property.md
+++ b/_includes/v2/security/secured_property.md
@@ -15,7 +15,7 @@ const User = Class.create({
 });
 ```
 
-As you can see, we switched on security for every operation on this class. Now let's see how to secure only certain operations.
+As you can see, we switched security off for every operation on this class. Now let's see how to secure only certain operations.
 
 ```js
 import { Class } from 'meteor/jagi:astronomy';
@@ -23,17 +23,16 @@ import { Class } from 'meteor/jagi:astronomy';
 const User = Class.create({
   name: 'User',
   /* ... */
-  // Turn off security for insert and update operations.
+  // Turn off security for update operations.
   secured: {
-    insert: false,
     update: false
   }
 });
 ```
 
-In the example above, we turned off security only for insert and update operations.
+In the example above, we turned off security only for update operations.
 
-Now let's see what will happen if you try insert something with secured inserts turned on.
+Now let's see what will happen if you try insert something.
 
 ```js
 var user = new User();


### PR DESCRIPTION
- Typos in Inheritance
- Correct repository link for Examples
- Typo in Find-event
- Fix false logic in the section about Secured-property
