### PR TITLE
Fixed a bug where options was written directly

### DIFF
--- a/lib/modules/storage/class_static_methods/find.js
+++ b/lib/modules/storage/class_static_methods/find.js
@@ -23,8 +23,7 @@ function createMethod(methodName) {
     selector = Mongo.Collection._rewriteSelector(selector);
 
     // Set default options.
-    options = options || {};
-    _.defaults(options, {
+    options = _.defaults({}, options, {
       defaults: true,
       children: true
     });
@@ -84,7 +83,7 @@ function createMethod(methodName) {
 
     return result;
   };
-};
+}
 
 const find = createMethod('find');
 const findOne = createMethod('findOne');


### PR DESCRIPTION
Had to use Object.assign() to do an actual clone/copy to avoid copy by ref

Fixes #495
