### PR TITLE
Correctly validate NaN

### DIFF
--- a/lib/modules/validators/validators/type/number.js
+++ b/lib/modules/validators/validators/type/number.js
@@ -4,7 +4,7 @@ import Validator from '../../validator.js';
 Validator.create({
   name: 'number',
   isValid({ value }) {
-    return _.isNumber(value);
+    return !_.isNaN(value) && _.isNumber(value);
   },
   resolveError({ name }) {
     return `"${name}" has to be a number`;


### PR DESCRIPTION
In a Number field If we use cast:true on a string which is not a number eg: "aaaa" the result will be NaN and Number validation will not work.

https://lodash.com/docs/4.17.2#isNumber