### PR TITLE
Add missing lodash import

### DIFF
--- a/lib/modules/storage/utils/class_upsert.js
+++ b/lib/modules/storage/utils/class_upsert.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import AstroClass from '../../../core/class.js';
 import alreadyInSimulation from './already_in_simulation.js';
 import throwIfSelectorIsNotId from './throw_if_selector_is_not_id.js';


### PR DESCRIPTION
This caused some problems for me in the latest released version, although I suspect that nobody else has had an issue because my setup is somewhat unique (I'm transpiling server-side code with babel before handing it off to Meteor and bundling client-side code with webpack).

In a more traditional Meteor environment I suspect this hasn't thrown errors for anyone simply because _ in this one file ends up being the global underscore import.  Since you are using lodash in the rest of the code I suspected this wasn't intentional.