### PR TITLE
Allow retrieving list of values from an Enum type

### DIFF
--- a/lib/modules/fields/Enum.js
+++ b/lib/modules/fields/Enum.js
@@ -46,6 +46,9 @@ const Enum = {
     const Enum = function Enum(identifier) {
       return Enum[identifier];
     };
+    Enum.getValues = function() {
+        return values;
+    };
     Enum.getIdentifiers = function() {
       return keys;
     };


### PR DESCRIPTION
This PR introduce a new function `getValues` which return every values used to construct the Enum during the declaration process.

This is the implementation of #668.