### PR TITLE
Text change to better describe the behavior

### DIFF
--- a/_includes/v2/key_concepts/fields_definition/immutable_fields.md
+++ b/_includes/v2/key_concepts/fields_definition/immutable_fields.md
@@ -1,6 +1,6 @@
 # Immutable fields
 
-If you want some field to be immutable you should set the `immutable` flag in the definition of a field. It won't be possible to change field's value once it has been persisted in the database. Let's take a look at the example.
+If you want some field to be immutable you should set the `immutable` flag in the definition of a field. It won't be possible to change the field's value once the document has been persisted in the database. Let's take a look at the example.
 
 ```js
 import { Class } from 'meteor/jagi:astronomy';
@@ -17,7 +17,7 @@ const User = Class.create({
 var user = new User();
 // It's possible to set a value.
 user.createdAt = new Date('2015-09-14');
-// It's possible to change a value as long as it was not save into database.
+// It's possible to change the value as long as the document isn't saved into the database.
 user.createdAt = new Date('2015-09-15');
 user.save();
 // Now setting a value will be denied.


### PR DESCRIPTION
It seems that you cannot change an immutable field's value if the document has been saved. Even if you save the document omitting the immutable field entirely (and it's optional). I made a change to the documentation to better explain this behavior.