### PR TITLE
Make astronomy redis-oplog compatible

### DIFF
--- a/.versions
+++ b/.versions
@@ -29,12 +29,12 @@ fetch@0.1.1
 geojson-utils@1.0.10
 html-tools@1.0.11
 htmljs@1.0.11
-hubroedu:astronomy@2.7.2
 id-map@1.1.0
 insecure@1.0.7
 inter-process-messaging@0.1.0
+jagi:astronomy@2.7.2
 jquery@1.11.10
-local-test:hubroedu:astronomy@2.7.2
+local-test:jagi:astronomy@2.7.2
 logging@1.1.20
 mdg:validation-error@0.5.1
 meteor@1.9.3

--- a/.versions
+++ b/.versions
@@ -29,12 +29,12 @@ fetch@0.1.1
 geojson-utils@1.0.10
 html-tools@1.0.11
 htmljs@1.0.11
+hubroedu:astronomy@2.7.2
 id-map@1.1.0
 insecure@1.0.7
 inter-process-messaging@0.1.0
-jagi:astronomy@2.7.1
 jquery@1.11.10
-local-test:jagi:astronomy@2.7.1
+local-test:hubroedu:astronomy@2.7.2
 logging@1.1.20
 mdg:validation-error@0.5.1
 meteor@1.9.3

--- a/lib/core/ejson.js
+++ b/lib/core/ejson.js
@@ -3,6 +3,16 @@ import Event from '../modules/events/event.js';
 
 EJSON.addType('Astronomy', function(json) {
   let Class = AstroClass.get(json.class);
+
+  // This sometimes happens on the client if a document arrives from a sub before all
+  // classes have been initialized in the app.
+  // One such sub can be the null-sub for user document, which sometimes can arrive before the
+  // app is fully ready.
+  if (!Class) {
+    console.warn(`[Astronomy] a document of class ${json.class} arrived before class was initialized`);
+    return EJSON.parse(json.values);
+  }
+
   let doc = new Class();
 
   // Trigger the "fromJSONValue" event handlers.

--- a/lib/modules/storage/class_prototype_methods/save.js
+++ b/lib/modules/storage/class_prototype_methods/save.js
@@ -134,6 +134,7 @@ function save(options = {}, callback) {
       doc,
       stopOnFirstError: options.stopOnFirstError,
       simulation: options.simulation,
+      pushToRedis: options.pushToRedis,
       trusted: true
     };
     if (inserting) {

--- a/lib/modules/storage/utils/document_insert.js
+++ b/lib/modules/storage/utils/document_insert.js
@@ -30,7 +30,6 @@ function documentInsert(args = {}) {
     doc._id = Collection._makeNewID();
   }
 
-
   // Check if a class is secured.
   if (Class.isSecured('insert') && Meteor.isServer && !trusted) {
     throw new Meteor.Error(403, 'Inserting from the client is not allowed');

--- a/lib/modules/storage/utils/document_insert.js
+++ b/lib/modules/storage/utils/document_insert.js
@@ -30,6 +30,7 @@ function documentInsert(args = {}) {
     doc._id = Collection._makeNewID();
   }
 
+
   // Check if a class is secured.
   if (Class.isSecured('insert') && Meteor.isServer && !trusted) {
     throw new Meteor.Error(403, 'Inserting from the client is not allowed');
@@ -76,7 +77,15 @@ function documentInsert(args = {}) {
     // server it returns array of inserted documents. So we always return the
     // generated id. We can't send an entire document because it could be a
     // security issue if we are not subscribed to all fields of a document.
-    Collection._collection.insert(values);
+    if (Meteor.isServer) {
+      // Use mongo's normal collection methods, to allow interop with other packages
+      // that override it.
+      Collection.insert(values);
+    } else {
+      // Avoid Meteor calling insert method from client,
+      // we do this ourselves
+      Collection._collection.insert(values);
+    }
 
     // Change the "_isNew" flag to "false". Mark a document as not new.
     doc._isNew = false;

--- a/lib/modules/storage/utils/document_remove.js
+++ b/lib/modules/storage/utils/document_remove.js
@@ -32,9 +32,21 @@ function documentRemove(args = {}) {
 
   // Remove a document.
   try {
-    const result = Collection._collection.remove({
-      _id: doc._id
-    });
+    let result;
+
+    if (Meteor.isServer) {
+      // Use mongo's normal collection methods, to allow interop with other packages
+      // that override it.
+      result = Collection.remove({
+        _id: doc._id
+      });
+    } else {
+      // Avoid Meteor calling insert method from client,
+      // we do this ourselves
+      result = Collection._collection.remove({
+        _id: doc._id
+      });
+    }
 
     // Mark a document as new, so it will be possible to save it again.
     doc._isNew = true;

--- a/lib/modules/storage/utils/document_update.js
+++ b/lib/modules/storage/utils/document_update.js
@@ -97,12 +97,27 @@ function documentUpdate(args = {}) {
   }
   // Update a document.
   try {
-    const result = Collection._collection.update(
-      {
-        _id: doc._id
-      },
-      modifier
-    );
+    let result;
+
+    if (Meteor.isServer) {
+      // Use mongo's normal collection methods, to allow interop with other packages
+      // that override it.
+      result = Collection._collection.update(
+        {
+          _id: doc._id
+        },
+        modifier
+      );
+    } else {
+      // Avoid Meteor calling insert method from client,
+      // we do this ourselves
+      result = Collection._collection.update(
+        {
+          _id: doc._id
+        },
+        modifier
+      );
+    }
 
     // Trigger after events.
     triggerAfterUpdate(args);

--- a/lib/modules/storage/utils/document_update.js
+++ b/lib/modules/storage/utils/document_update.js
@@ -1,5 +1,6 @@
 import _omit from "lodash/omit";
 import _size from "lodash/size";
+import _isUndefined from "lodash/isUndefined";
 import castNested from "../../fields/utils/castNested";
 import triggerBeforeSave from "./trigger_before_save";
 import triggerBeforeUpdate from "./trigger_before_update";

--- a/lib/modules/storage/utils/document_update.js
+++ b/lib/modules/storage/utils/document_update.js
@@ -102,7 +102,7 @@ function documentUpdate(args = {}) {
     if (Meteor.isServer) {
       // Use mongo's normal collection methods, to allow interop with other packages
       // that override it.
-      result = Collection._collection.update(
+      result = Collection.update(
         {
           _id: doc._id
         },

--- a/lib/modules/storage/utils/document_update.js
+++ b/lib/modules/storage/utils/document_update.js
@@ -17,6 +17,7 @@ function documentUpdate(args = {}) {
     simulation = true,
     forceUpdate = false,
     trusted = false,
+    pushToRedis
     oldDoc
   } = args;
 
@@ -98,6 +99,11 @@ function documentUpdate(args = {}) {
   // Update a document.
   try {
     let result;
+    let options = {};
+
+    if (!_isUndefined(pushToRedis)) {
+      options.pushToRedis = pushToRedis;
+    }
 
     if (Meteor.isServer) {
       // Use mongo's normal collection methods, to allow interop with other packages
@@ -106,7 +112,8 @@ function documentUpdate(args = {}) {
         {
           _id: doc._id
         },
-        modifier
+        modifier,
+        options
       );
     } else {
       // Avoid Meteor calling insert method from client,

--- a/lib/modules/storage/utils/document_update.js
+++ b/lib/modules/storage/utils/document_update.js
@@ -17,7 +17,7 @@ function documentUpdate(args = {}) {
     simulation = true,
     forceUpdate = false,
     trusted = false,
-    pushToRedis
+    pushToRedis,
     oldDoc
   } = args;
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "hubroedu:astronomy",
-  version: "2.7.2.1",
+  version: "2.7.2_1",
   summary: "Model layer for Meteor",
   git: "https://github.com/hubroedu/meteor-astronomy.git"
 });

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
-  name: "jagi:astronomy",
-  version: "2.7.2",
+  name: "hubroedu:astronomy",
+  version: "2.7.2.1",
   summary: "Model layer for Meteor",
-  git: "https://github.com/jagi/meteor-astronomy.git"
+  git: "https://github.com/hubroedu/meteor-astronomy.git"
 });
 
 Npm.depends({
@@ -41,7 +41,7 @@ Package.onTest(function(api) {
       "insecure",
       "mongo",
       "ejson",
-      "jagi:astronomy@2.5.8"
+      "hubroedu:astronomy@2.5.8"
     ],
     ["client", "server"]
   );

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
-  name: "hubroedu:astronomy",
-  version: "2.7.2_1",
+  name: "jagi:astronomy",
+  version: "2.7.2",
   summary: "Model layer for Meteor",
-  git: "https://github.com/hubroedu/meteor-astronomy.git"
+  git: "https://github.com/jagi/meteor-astronomy.git"
 });
 
 Npm.depends({
@@ -41,7 +41,7 @@ Package.onTest(function(api) {
       "insecure",
       "mongo",
       "ejson",
-      "hubroedu:astronomy@2.5.8"
+      "jagi:astronomy@2.5.8"
     ],
     ["client", "server"]
   );


### PR DESCRIPTION
So according to #555 and https://github.com/cult-of-coders/redis-oplog/issues/235#issuecomment-364043055, it is explained that the reason Astronomy uses _collection is to avoid the meteor methods on the client.

This has the unfortunate side-effect that it is not compatible with other packages that listens to or overrides the normal Collection methods, like redis-oplog. For me, this is a big problem, as I will be needing this package very soon and I don't want to rewrite everything away from Astronomy, or use some hack to make them play together.

My thoughts regarding overriding the collection methods by other packages is that it is up to the user to determine if they want to add packages that do this or not, and they have to accept the consequences.

I am opening this PR to explore a suggestion, which is simply to call the _collection functions on the client, but the Collection functions on the server. As far as I can tell, this will ensure that meteor methods are not called and still allow overriding if people want that.

Oh, and I added a fallback for cases where the astronomy class has not been initialized, which happened sometimes on initial load with redis-oplog enabled. I think the increased speed discovered a race condition, where the user doc arrived before my custom User doc definitions were initialized.

Let me know what you think! :smile: 