### PR TITLE
Support for mongo transactions

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -1,6 +1,11 @@
 {
   "lockfileVersion": 1,
   "dependencies": {
+    "bignumber.js": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+    },
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",

--- a/README.md
+++ b/README.md
@@ -99,6 +99,33 @@ const Post = Class.create({
 });
 ```
 
+## Mongo Transactions Support
+
+```js
+import Post from './post'
+import User from './user'
+import { MongoInternals } from 'meteor/mongo';
+
+let post = Post.find(postQuery);
+let user = User.find(userQuery);
+
+post.userId = user._id;
+user.posts.push(post);
+
+const { client } = MongoInternals.defaultRemoteCollectionDriver().mongo;
+const session = await client.startSession();
+await session.startTransaction();
+try {
+  post.save({session});
+  user.save({session});
+  await session.commitTransaction();
+} catch (e) {
+  await session.abortTransaction();
+} finally {
+  session.endSession();
+}
+```
+
 ## Supporters
 
 [<img src="http://jagi.github.io/meteor-astronomy/images/usefulio.png" />](http://useful.io/)

--- a/lib/modules/fields/module.js
+++ b/lib/modules/fields/module.js
@@ -6,6 +6,7 @@ import './types/mongo_object_id.js';
 import './types/number.js';
 import './types/object.js';
 import './types/string.js';
+import './types/decimal.js';
 // Utils.
 import castNested from './utils/castNested';
 import getAll from './utils/getAll';

--- a/lib/modules/fields/types/decimal.js
+++ b/lib/modules/fields/types/decimal.js
@@ -1,0 +1,14 @@
+import Type from '../type.js';
+import Validators from '../../validators/validators.js';
+import { Decimal } from 'meteor/mongo-decimal';
+
+Type.create({
+  name: 'Decimal',
+  class: Decimal,
+  cast(value) {
+    Decimal(value.toString())
+  },
+  validate(args) {
+    Decimal.isDecimal(args)
+  }
+});

--- a/lib/modules/storage/class_prototype_methods/remove.js
+++ b/lib/modules/storage/class_prototype_methods/remove.js
@@ -57,7 +57,8 @@ function remove(args = {}, callback) {
     let methodArgs = {
       doc,
       simulation,
-      trusted: true
+      trusted: true,
+      session: args.session
     };
     let result = documentRemove(methodArgs);
     if (callback) {

--- a/lib/modules/storage/class_prototype_methods/save.js
+++ b/lib/modules/storage/class_prototype_methods/save.js
@@ -134,7 +134,8 @@ function save(options = {}, callback) {
       doc,
       stopOnFirstError: options.stopOnFirstError,
       simulation: options.simulation,
-      trusted: true
+      trusted: true,
+      session: options.session
     };
     if (inserting) {
       let result = documentInsert(methodArgs);

--- a/lib/modules/storage/class_static_methods/insert.js
+++ b/lib/modules/storage/class_static_methods/insert.js
@@ -2,15 +2,25 @@ import isRemote from '../utils/is_remote.js';
 import callMeteorMethod from '../utils/call_meteor_method.js';
 import classInsert from '../utils/class_insert.js';
 
-function insert(rawDoc, callback) {
+function insert(rawDoc, options, callback) {
   const Class = this;
   const Collection = Class.getCollection();
+
+  // If we omit options argument then it may be a callback function.
+  if (options instanceof Function) {
+    callback = options;
+    options = {};
+  }
 
   // Prepare arguments.
   const args = {
     className: Class.getName(),
     rawDoc
   };
+
+  if (options && options.session) {
+    args.session = options.session
+  }
 
   // Generate ID if not provided.
   if (!rawDoc._id) {

--- a/lib/modules/storage/utils/class_insert.js
+++ b/lib/modules/storage/utils/class_insert.js
@@ -9,6 +9,7 @@ function classInsert(args = {}) {
     fields,
     simulation = true,
     trusted = false,
+    session
   } = args;
 
   // Stop execution, if we are not on the server, when the "simulation" flag is
@@ -27,6 +28,7 @@ function classInsert(args = {}) {
     stopOnFirstError,
     simulation,
     trusted,
+    session
   });
 };
 

--- a/lib/modules/storage/utils/class_remove.js
+++ b/lib/modules/storage/utils/class_remove.js
@@ -9,7 +9,7 @@ function classRemove(args = {}) {
     selector,
     options,
     simulation = true,
-    trusted = false
+    trusted = false,
   } = args;
 
   // Stop execution, if we are not on the server, when the "simulation" flag is
@@ -35,7 +35,8 @@ function classRemove(args = {}) {
     result += documentRemove({
       doc,
       simulation,
-      trusted
+      trusted,
+      session: options && options.session
     });
   });
 

--- a/lib/modules/storage/utils/class_update.js
+++ b/lib/modules/storage/utils/class_update.js
@@ -86,7 +86,8 @@ function classUpdate(args = {}) {
       simulation,
       fields,
       trusted,
-      oldDoc
+      oldDoc,
+      session: options.session
     });
   });
 

--- a/lib/modules/storage/utils/class_upsert.js
+++ b/lib/modules/storage/utils/class_upsert.js
@@ -74,7 +74,8 @@ function classUpsert(args = {}) {
         stopOnFirstError,
         simulation,
         fields,
-        trusted
+        trusted,
+        session: options.session
       });
     });
   }
@@ -102,6 +103,7 @@ function classUpsert(args = {}) {
       stopOnFirstError,
       simulation,
       trusted,
+      session: options.session
     });
   }
 

--- a/lib/modules/storage/utils/document_insert.js
+++ b/lib/modules/storage/utils/document_insert.js
@@ -6,6 +6,7 @@ import triggerBeforeInsert from './trigger_before_insert';
 import triggerAfterSave from './trigger_after_save';
 import triggerAfterInsert from './trigger_after_insert';
 import documentValidate from '../../validators/utils/document_validate';
+import { replaceTypes, replaceMeteorAtomWithMongo } from './replace_types';
 
 function documentInsert(args = {}) {
   const {
@@ -78,7 +79,9 @@ function documentInsert(args = {}) {
     // generated id. We can't send an entire document because it could be a
     // security issue if we are not subscribed to all fields of a document.
     if (session) {
-      Promise.await(Collection.rawCollection().insertOne(values, {session}));
+      values = replaceTypes(values, replaceMeteorAtomWithMongo);
+      // console.log(values)
+      Promise.await(Collection.rawCollection().insert(values, {session}));
     } else {
       Collection._collection.insert(values);
     }

--- a/lib/modules/storage/utils/document_insert.js
+++ b/lib/modules/storage/utils/document_insert.js
@@ -24,6 +24,9 @@ function documentInsert(args = {}) {
     return;
   }
 
+  const options = {}
+  if (session) options.session = session;
+
   const Class = doc.constructor;
   const Collection = Class.getCollection();
 
@@ -78,13 +81,13 @@ function documentInsert(args = {}) {
     // server it returns array of inserted documents. So we always return the
     // generated id. We can't send an entire document because it could be a
     // security issue if we are not subscribed to all fields of a document.
-    if (session) {
-      values = replaceTypes(values, replaceMeteorAtomWithMongo);
-      // console.log(values)
-      Promise.await(Collection.rawCollection().insert(values, {session}));
-    } else {
-      Collection._collection.insert(values);
-    }
+    // if (session) {
+    //   values = replaceTypes(values, replaceMeteorAtomWithMongo);
+    //   Promise.await(Collection.rawCollection().insert(values, {session}));
+    // } else {
+    //   Collection._collection.insert(values);
+    // }
+    Collection._collection.insert(values, options);
 
     // Change the "_isNew" flag to "false". Mark a document as not new.
     doc._isNew = false;

--- a/lib/modules/storage/utils/document_insert.js
+++ b/lib/modules/storage/utils/document_insert.js
@@ -13,7 +13,8 @@ function documentInsert(args = {}) {
     stopOnFirstError,
     fields,
     simulation = true,
-    trusted = false
+    trusted = false,
+    session
   } = args;
 
   // Stop execution, if we are not on the server, when the "simulation" flag is
@@ -76,7 +77,11 @@ function documentInsert(args = {}) {
     // server it returns array of inserted documents. So we always return the
     // generated id. We can't send an entire document because it could be a
     // security issue if we are not subscribed to all fields of a document.
-    Collection._collection.insert(values);
+    if (session) {
+      Promise.await(Collection.rawCollection().insertOne(values, {session}));
+    } else {
+      Collection._collection.insert(values);
+    }
 
     // Change the "_isNew" flag to "false". Mark a document as not new.
     doc._isNew = false;

--- a/lib/modules/storage/utils/document_remove.js
+++ b/lib/modules/storage/utils/document_remove.js
@@ -15,6 +15,9 @@ function documentRemove(args = {}) {
     return;
   }
 
+  const options = {}
+  if (session) options.session = session;
+
   const Class = doc.constructor;
   const Collection = Class.getCollection();
 
@@ -34,15 +37,18 @@ function documentRemove(args = {}) {
   // Remove a document.
   try {
     let result
-    if (session) {
-      result = Promise.await(Collection.rawCollection().remove({
-        _id: doc._id
-      }, {session}));
-    } else {
-      result = Collection._collection.remove({
-        _id: doc._id
-      });
-    }
+    // if (session) {
+    //   result = Promise.await(Collection.rawCollection().remove({
+    //     _id: doc._id
+    //   }, {session}));
+    // } else {
+    //   result = Collection._collection.remove({
+    //     _id: doc._id
+    //   });
+    // }
+    result = Collection._collection.remove({
+      _id: doc._id
+    }, options);
 
     // Mark a document as new, so it will be possible to save it again.
     doc._isNew = true;

--- a/lib/modules/storage/utils/document_remove.js
+++ b/lib/modules/storage/utils/document_remove.js
@@ -5,7 +5,8 @@ function documentRemove(args = {}) {
   const {
     doc,
     simulation = true,
-    trusted = false
+    trusted = false,
+    session
   } = args;
 
   // Stop execution, if we are not on the server, when the "simulation" flag is
@@ -32,9 +33,16 @@ function documentRemove(args = {}) {
 
   // Remove a document.
   try {
-    const result = Collection._collection.remove({
-      _id: doc._id
-    });
+    let result
+    if (session) {
+      result = Promise.await(Collection.rawCollection().remove({
+        _id: doc._id
+      }, {session}));
+    } else {
+      result = Collection._collection.remove({
+        _id: doc._id
+      });
+    }
 
     // Mark a document as new, so it will be possible to save it again.
     doc._isNew = true;

--- a/lib/modules/storage/utils/document_update.js
+++ b/lib/modules/storage/utils/document_update.js
@@ -17,7 +17,8 @@ function documentUpdate(args = {}) {
     simulation = true,
     forceUpdate = false,
     trusted = false,
-    oldDoc
+    oldDoc,
+    session
   } = args;
 
   // Stop execution, if we are not on the server, when the "simulation" flag is
@@ -97,13 +98,23 @@ function documentUpdate(args = {}) {
   }
   // Update a document.
   try {
-    const result = Collection._collection.update(
-      {
-        _id: doc._id
-      },
-      modifier
-    );
-
+    let result;
+    if (session && Meteor.isServer) {
+      result = Promise.await(Collection.rawCollection().updateOne(
+        {
+          _id: doc._id
+        },
+        modifier,
+        {session}
+      ));
+    } else {
+      result = Collection._collection.update(
+        {
+          _id: doc._id
+        },
+        modifier
+      );
+    }
     // Trigger after events.
     triggerAfterUpdate(args);
     triggerAfterSave(args);

--- a/lib/modules/storage/utils/document_update.js
+++ b/lib/modules/storage/utils/document_update.js
@@ -28,6 +28,9 @@ function documentUpdate(args = {}) {
     return;
   }
 
+  const options = {}
+  if (session) options.session = session;
+
   let Class = doc.constructor;
   let Collection = Class.getCollection();
 
@@ -100,23 +103,31 @@ function documentUpdate(args = {}) {
   // Update a document.
   try {
     let result;
-    if (session && Meteor.isServer) {
-      let _modifier = replaceTypes(modifier, replaceMeteorAtomWithMongo);
-      result = Promise.await(Collection.rawCollection().updateOne(
-        {
-          _id: doc._id
-        },
-        _modifier,
-        {session}
-      ));
-    } else {
-      result = Collection._collection.update(
-        {
-          _id: doc._id
-        },
-        modifier
-      );
-    }
+    // if (session && Meteor.isServer) {
+    //   let _modifier = replaceTypes(modifier, replaceMeteorAtomWithMongo);
+    //   result = Promise.await(Collection.rawCollection().updateOne(
+    //     {
+    //       _id: doc._id
+    //     },
+    //     _modifier,
+    //     {session}
+    //   ));
+    // } else {
+    //   result = Collection._collection.update(
+    //     {
+    //       _id: doc._id
+    //     },
+    //     modifier
+    //   );
+    // }
+    console.log('document_update', modifier)
+    result = Collection._collection.update(
+      {
+        _id: doc._id
+      },
+      modifier,
+      options
+    );
     // Trigger after events.
     triggerAfterUpdate(args);
     triggerAfterSave(args);

--- a/lib/modules/storage/utils/document_update.js
+++ b/lib/modules/storage/utils/document_update.js
@@ -120,7 +120,7 @@ function documentUpdate(args = {}) {
     //     modifier
     //   );
     // }
-    console.log('document_update', modifier)
+    // console.log('document_update', modifier)
     result = Collection._collection.update(
       {
         _id: doc._id

--- a/lib/modules/storage/utils/document_update.js
+++ b/lib/modules/storage/utils/document_update.js
@@ -8,6 +8,7 @@ import triggerAfterUpdate from "./trigger_after_update";
 import isModified from "./isModified";
 import getModifier from "./getModifier";
 import documentValidate from "../../validators/utils/document_validate";
+import { replaceTypes, replaceMeteorAtomWithMongo } from './replace_types';
 
 function documentUpdate(args = {}) {
   let {
@@ -100,11 +101,12 @@ function documentUpdate(args = {}) {
   try {
     let result;
     if (session && Meteor.isServer) {
+      let _modifier = replaceTypes(modifier, replaceMeteorAtomWithMongo);
       result = Promise.await(Collection.rawCollection().updateOne(
         {
           _id: doc._id
         },
-        modifier,
+        _modifier,
         {session}
       ));
     } else {

--- a/lib/modules/storage/utils/getModifier.js
+++ b/lib/modules/storage/utils/getModifier.js
@@ -116,8 +116,8 @@ handlers.onScalarDiff = function({ oldValue, newValue, prefix, result }) {
       !_isNaN(newValue)
     ) {
       result.$inc[prefix] = newValue - oldValue;
-    } else if (oldValue instanceof Decimal && newValue instanceof Decimal) {
-      result.$inc[prefix] = newValue.minus(oldValue)
+    } else if (oldValue instanceof Decimal || newValue instanceof Decimal) {
+      result.$inc[prefix] = Decimal(newValue || '0').minus(oldValue || '0')
     } else {
       result.$set[prefix] = newValue;
     }

--- a/lib/modules/storage/utils/getModifier.js
+++ b/lib/modules/storage/utils/getModifier.js
@@ -117,7 +117,8 @@ handlers.onScalarDiff = function({ oldValue, newValue, prefix, result }) {
     ) {
       result.$inc[prefix] = newValue - oldValue;
     } else if (oldValue instanceof Decimal || newValue instanceof Decimal) {
-      result.$inc[prefix] = Decimal(newValue || '0').minus(oldValue || '0').toDecimalPlaces(8)
+      // result.$inc[prefix] = Decimal(newValue || '0').minus(oldValue || '0')
+      result.$set[prefix] = newValue;
     } else {
       result.$set[prefix] = newValue;
     }

--- a/lib/modules/storage/utils/getModifier.js
+++ b/lib/modules/storage/utils/getModifier.js
@@ -5,6 +5,7 @@ import _isPlainObject from "lodash/isPlainObject";
 import _omitBy from "lodash/omitBy";
 import _size from "lodash/size";
 import { EJSON } from "meteor/ejson";
+import { Decimal } from 'meteor/mongo-decimal'
 import throwParseError from "../../core/utils/throw_parse_error.js";
 import rawMany from "../../fields/utils/rawMany";
 import diff from "./diff";
@@ -115,6 +116,8 @@ handlers.onScalarDiff = function({ oldValue, newValue, prefix, result }) {
       !_isNaN(newValue)
     ) {
       result.$inc[prefix] = newValue - oldValue;
+    } else if (oldValue instanceof Decimal && newValue instanceof Decimal) {
+      result.$inc[prefix] = newValue.minus(oldValue)
     } else {
       result.$set[prefix] = newValue;
     }

--- a/lib/modules/storage/utils/getModifier.js
+++ b/lib/modules/storage/utils/getModifier.js
@@ -117,7 +117,7 @@ handlers.onScalarDiff = function({ oldValue, newValue, prefix, result }) {
     ) {
       result.$inc[prefix] = newValue - oldValue;
     } else if (oldValue instanceof Decimal || newValue instanceof Decimal) {
-      result.$inc[prefix] = Decimal(newValue || '0').minus(oldValue || '0')
+      result.$inc[prefix] = Decimal(newValue || '0').minus(oldValue || '0').toDecimalPlaces(8)
     } else {
       result.$set[prefix] = newValue;
     }

--- a/lib/modules/storage/utils/replace_types.js
+++ b/lib/modules/storage/utils/replace_types.js
@@ -1,0 +1,93 @@
+import { NpmModuleMongodb as MongoDB } from 'meteor/npm-mongo';
+import { EJSON } from 'meteor/ejson';
+import { _ } from 'meteor/underscore'
+
+var replaceNames = function (filter, thing) {
+  if (typeof thing === "object" && thing !== null) {
+    if (_.isArray(thing)) {
+      return _.map(thing, _.bind(replaceNames, null, filter));
+    }
+    var ret = {};
+    _.each(thing, function (value, key) {
+      ret[filter(key)] = replaceNames(filter, value);
+    });
+    return ret;
+  }
+  return thing;
+};
+
+var makeMongoLegal = function (name) { return "EJSON" + name; };
+var unmakeMongoLegal = function (name) { return name.substr(5); };
+
+export var replaceMongoAtomWithMeteor = function (document) {
+  if (document instanceof MongoDB.Binary) {
+    var buffer = document.value(true);
+    return new Uint8Array(buffer);
+  }
+  if (document instanceof MongoDB.ObjectID) {
+    return new Mongo.ObjectID(document.toHexString());
+  }
+  if (document instanceof MongoDB.Decimal128) {
+    return Decimal(document.toString());
+  }
+  if (document["EJSON$type"] && document["EJSON$value"] && _.size(document) === 2) {
+    return EJSON.fromJSONValue(replaceNames(unmakeMongoLegal, document));
+  }
+  if (document instanceof MongoDB.Timestamp) {
+    // For now, the Meteor representation of a Mongo timestamp type (not a date!
+    // this is a weird internal thing used in the oplog!) is the same as the
+    // Mongo representation. We need to do this explicitly or else we would do a
+    // structural clone and lose the prototype.
+    return document;
+  }
+  return undefined;
+};
+
+export var replaceMeteorAtomWithMongo = function (document) {
+  if (EJSON.isBinary(document)) {
+    // This does more copies than we'd like, but is necessary because
+    // MongoDB.BSON only looks like it takes a Uint8Array (and doesn't actually
+    // serialize it correctly).
+    return new MongoDB.Binary(Buffer.from(document));
+  }
+  if (document instanceof Mongo.ObjectID) {
+    return new MongoDB.ObjectID(document.toHexString());
+  }
+  if (document instanceof MongoDB.Timestamp) {
+    // For now, the Meteor representation of a Mongo timestamp type (not a date!
+    // this is a weird internal thing used in the oplog!) is the same as the
+    // Mongo representation. We need to do this explicitly or else we would do a
+    // structural clone and lose the prototype.
+    return document;
+  }
+  if (document instanceof Decimal) {
+    return MongoDB.Decimal128.fromString(document.toString());
+  }
+  if (EJSON._isCustomType(document)) {
+    return replaceNames(makeMongoLegal, EJSON.toJSONValue(document));
+  }
+  // It is not ordinarily possible to stick dollar-sign keys into mongo
+  // so we don't bother checking for things that need escaping at this time.
+  return undefined;
+};
+
+export var replaceTypes = function (document, atomTransformer) {
+  if (typeof document !== 'object' || document === null)
+    return document;
+
+  var replacedTopLevelAtom = atomTransformer(document);
+  if (replacedTopLevelAtom !== undefined)
+    return replacedTopLevelAtom;
+
+  var ret = document;
+  _.each(document, function (val, key) {
+    var valReplaced = replaceTypes(val, atomTransformer);
+    if (val !== valReplaced) {
+      // Lazy clone. Shallow copy.
+      if (ret === document)
+        ret = _.clone(document);
+      ret[key] = valReplaced;
+    }
+  });
+  return ret;
+};

--- a/lib/modules/storage/utils/replace_types.js
+++ b/lib/modules/storage/utils/replace_types.js
@@ -1,6 +1,7 @@
 import { NpmModuleMongodb as MongoDB } from 'meteor/npm-mongo';
 import { EJSON } from 'meteor/ejson';
 import { _ } from 'meteor/underscore'
+import BigNumber from 'bignumber.js'
 
 var replaceNames = function (filter, thing) {
   if (typeof thing === "object" && thing !== null) {
@@ -29,6 +30,9 @@ export var replaceMongoAtomWithMeteor = function (document) {
   }
   if (document instanceof MongoDB.Decimal128) {
     return Decimal(document.toString());
+  }
+  if (document instanceof MongoDB.Long) {
+    return BigNumber(document.toString());
   }
   if (document["EJSON$type"] && document["EJSON$value"] && _.size(document) === 2) {
     return EJSON.fromJSONValue(replaceNames(unmakeMongoLegal, document));
@@ -62,6 +66,9 @@ export var replaceMeteorAtomWithMongo = function (document) {
   }
   if (document instanceof Decimal) {
     return MongoDB.Decimal128.fromString(document.toString());
+  }
+  if (BigNumber.isBigNumber(document)) {
+    return MongoDB.Long.fromString(document.toString());
   }
   if (EJSON._isCustomType(document)) {
     return replaceNames(makeMongoLegal, EJSON.toJSONValue(document));

--- a/lib/modules/storage/utils/replace_types.js
+++ b/lib/modules/storage/utils/replace_types.js
@@ -1,7 +1,7 @@
-import { NpmModuleMongodb as MongoDB } from 'meteor/npm-mongo';
+import { NpmModuleMongodb as MongoDB } from 'meteor/mongo';
 import { EJSON } from 'meteor/ejson';
 import { _ } from 'meteor/underscore'
-import BigNumber from 'bignumber.js'
+import BigNumber from 'bignumber.js';
 
 var replaceNames = function (filter, thing) {
   if (typeof thing === "object" && thing !== null) {

--- a/lib/modules/storage/utils/wrapTransform.js
+++ b/lib/modules/storage/utils/wrapTransform.js
@@ -1,4 +1,5 @@
 import resolveValues from '../../fields/utils/resolveValues';
+import { replaceTypes, replaceMongoAtomWithMeteor } from './replace_types';
 
 function wrapTransform(args = {}) {
   const {
@@ -11,6 +12,7 @@ function wrapTransform(args = {}) {
       rawDoc
     });
     resolvedValues._isNew = false;
+    resolvedValues.rawDoc = replaceTypes(resolvedValues.rawDoc, replaceMongoAtomWithMeteor);
     return transform(resolvedValues);
   }
 }

--- a/package.js
+++ b/package.js
@@ -19,6 +19,7 @@ Package.onUse(function(api) {
       "es5-shim",
       "ddp",
       "mongo",
+      "mongo-decimal",
       "check",
       "minimongo",
       "ejson",

--- a/package.js
+++ b/package.js
@@ -41,7 +41,8 @@ Package.onTest(function(api) {
       "insecure",
       "mongo",
       "ejson",
-      "jagi:astronomy@2.5.8"
+      "jagi:astronomy",
+      "promise"
     ],
     ["client", "server"]
   );

--- a/package.js
+++ b/package.js
@@ -6,7 +6,8 @@ Package.describe({
 });
 
 Npm.depends({
-  lodash: "4.17.11"
+  lodash: "4.17.11",
+  'bignumber.js': '9.0.0'
 });
 
 Package.onUse(function(api) {

--- a/test/modules/storage/class_insert.js
+++ b/test/modules/storage/class_insert.js
@@ -1,4 +1,6 @@
 import { Class } from 'meteor/jagi:astronomy';
+import { MongoInternals } from 'meteor/mongo';
+import { Promise } from 'meteor/promise';
 
 Tinytest.add('Modules - Storage - Class insert', function(test) {
   const Storage = Class.get('Storage');
@@ -48,3 +50,57 @@ Tinytest.add('Modules - Storage - Class insert', function(test) {
     'Document has not been inserted properly'
   );
 });
+
+if (Meteor.isServer) {
+  Tinytest.add('Modules - Storage - Class insert with Mongo Transactions', function(test) {
+    const Storage = Class.get('PersistentStorage');
+    const Collection = Storage.getCollection()
+    const _id = Collection._makeNewID()
+    const expected = {
+      _id,
+      string: 'Some String'
+    }
+
+    const { client } = MongoInternals.defaultRemoteCollectionDriver().mongo
+    session = Promise.await(client.startSession())
+    Promise.await(session.startTransaction())
+    try {
+      Storage.insert(expected, {session});
+      Promise.await(session.commitTransaction())
+    } catch (e) {
+      Promise.await(session.abortTransaction())
+    } finally {
+      Promise.await(session.endSession())
+    }
+    test.equal(Storage.findOne(_id, {
+      transform: null,
+    }), expected,
+      'Document has not been inserted properly'
+    );
+  });
+
+  Tinytest.add('Modules - Storage - Class insert with Mongo Transactions (Rollback)', function(test) {
+    const Storage = Class.get('PersistentStorage');
+    const Collection = Storage.getCollection()
+    const _id = Collection._makeNewID()
+    const expected = {
+      _id,
+      string: 'Some String'
+    }
+
+    const { client } = MongoInternals.defaultRemoteCollectionDriver().mongo
+    session = Promise.await(client.startSession())
+    Promise.await(session.startTransaction())
+    try {
+      Storage.insert(expected, {session});
+      throw new Meteor.Error(500, 'Throw error for testing purpose')
+      Promise.await(session.commitTransaction())
+    } catch (e) {
+      Promise.await(session.abortTransaction())
+    } finally {
+      Promise.await(session.endSession())
+    }
+    test.equal(Storage.findOne(_id), undefined, 'The document does not have to be saved')
+  });
+
+}

--- a/test/modules/storage/class_remove.js
+++ b/test/modules/storage/class_remove.js
@@ -1,4 +1,6 @@
 import { Class } from 'meteor/jagi:astronomy';
+import { MongoInternals } from 'meteor/mongo';
+import { Promise } from 'meteor/promise';
 
 Tinytest.add('Modules - Storage - Class remove', function(test) {
   const Storage = Class.get('Storage');
@@ -10,3 +12,62 @@ Tinytest.add('Modules - Storage - Class remove', function(test) {
     'Document has not been removed properly'
   );
 });
+
+if (Meteor.isServer) {
+  Tinytest.add('Modules - Storage - Class remove with Mongo Transactions', function(test) {
+    const Storage = Class.get('PersistentStorage');
+    const Collection = Storage.getCollection()
+    const _id = Collection._makeNewID()
+    const expected = {
+      _id,
+      string: 'Some String'
+    }
+    Storage.insert(expected);
+
+    const { client } = MongoInternals.defaultRemoteCollectionDriver().mongo
+    session = Promise.await(client.startSession())
+    Promise.await(session.startTransaction())
+    try {
+      Storage.remove({_id}, {session})
+      Promise.await(session.commitTransaction())
+    } catch (e) {
+      Promise.await(session.abortTransaction())
+    } finally {
+      Promise.await(session.endSession())
+    }
+    test.equal(Storage.findOne(_id), undefined,
+      'Document has not been removed properly'
+    );
+  });
+
+  Tinytest.add('Modules - Storage - Class remove with Mongo Transactions (Rollback)', function(test) {
+    const Storage = Class.get('PersistentStorage');
+    const Collection = Storage.getCollection()
+    const _id = Collection._makeNewID()
+    const expected = {
+      _id,
+      string: 'Some String'
+    }
+    Storage.insert(expected);
+
+    const { client } = MongoInternals.defaultRemoteCollectionDriver().mongo
+    session = Promise.await(client.startSession())
+    Promise.await(session.startTransaction())
+    try {
+      Storage.remove({_id}, {session})
+      throw new Meteor.Error(500, 'Throw error for testing purpose')
+      Promise.await(session.commitTransaction())
+    } catch (e) {
+      Promise.await(session.abortTransaction())
+    } finally {
+      Promise.await(session.endSession())
+    }
+    // console.log(Storage.findOne(_id))
+    test.equal(Storage.findOne(_id, {
+      transform: null,
+    }), expected,
+      'Document does not have to be removed'
+    );
+  });
+
+}

--- a/test/modules/storage/class_update.js
+++ b/test/modules/storage/class_update.js
@@ -1,4 +1,6 @@
 import { Class } from 'meteor/jagi:astronomy';
+import { MongoInternals } from 'meteor/mongo';
+import { Promise } from 'meteor/promise';
 
 Tinytest.add('Modules - Storage - Class update', function(test) {
   const Storage = Class.get('Storage');
@@ -48,3 +50,79 @@ Tinytest.add('Modules - Storage - Class update', function(test) {
     'Document has not been updated properly'
   );
 });
+
+if (Meteor.isServer) {
+  Tinytest.add('Modules - Storage - Class update with Mongo Transactions', function(test) {
+    const Storage = Class.get('PersistentStorage');
+    const Collection = Storage.getCollection()
+    const _id = Collection._makeNewID()
+    const initial = {
+      _id,
+      string: 'Some String'
+    }
+    const expected = {
+      _id,
+      string: 'Changed String'
+    }
+    Storage.insert(initial)
+
+    const { client } = MongoInternals.defaultRemoteCollectionDriver().mongo
+    session = Promise.await(client.startSession())
+    Promise.await(session.startTransaction())
+    try {
+      Storage.update({_id}, {
+        $set: {
+          string: 'Changed String'
+        }
+      }, {session})
+      Promise.await(session.commitTransaction())
+    } catch (e) {
+      Promise.await(session.abortTransaction())
+    } finally {
+      Promise.await(session.endSession())
+    }
+    test.equal(Storage.findOne(_id, {
+      transform: null
+    }), expected,
+      'Document has not been updated properly'
+    );
+  });
+
+  Tinytest.add('Modules - Storage - Class update with Mongo Transactions (Rollback)', function(test) {
+    const Storage = Class.get('PersistentStorage');
+    const Collection = Storage.getCollection()
+    const _id = Collection._makeNewID()
+    const initial = {
+      _id,
+      string: 'Some String'
+    }
+    const expected = {
+      _id,
+      string: 'Changed String'
+    }
+    Storage.insert(initial)
+
+    const { client } = MongoInternals.defaultRemoteCollectionDriver().mongo
+    session = Promise.await(client.startSession())
+    Promise.await(session.startTransaction())
+    try {
+      Storage.update({_id}, {
+        $set: {
+          string: 'Changed String'
+        }
+      }, {session})
+      throw new Meteor.Error(500, 'Throw error for testing purpose')
+      Promise.await(session.commitTransaction())
+    } catch (e) {
+      Promise.await(session.abortTransaction())
+    } finally {
+      Promise.await(session.endSession())
+    }
+    test.equal(Storage.findOne(_id, {
+      transform: null
+    }), initial,
+      'Document does not have to be updated'
+    );
+  });
+
+}

--- a/test/modules/storage/document_remove.js
+++ b/test/modules/storage/document_remove.js
@@ -1,4 +1,6 @@
 import { Class } from 'meteor/jagi:astronomy';
+import { MongoInternals } from 'meteor/mongo';
+import { Promise } from 'meteor/promise';
 
 Tinytest.add('Modules - Storage - Document remove', function(test) {
   const Storage = Class.get('Storage');
@@ -11,3 +13,59 @@ Tinytest.add('Modules - Storage - Document remove', function(test) {
     'The document has not been removed properly'
   );
 });
+
+if (Meteor.isServer) {
+  Tinytest.add('Modules - Storage - Document remove with Mongo Transactions', function(test) {
+    const Storage = Class.get('PersistentStorage');
+    const Collection = Storage.getCollection()
+    const expected = {
+      string: 'Some String'
+    }
+    const storage = new Storage(expected);
+    const _id = storage.save()
+
+    const { client } = MongoInternals.defaultRemoteCollectionDriver().mongo
+    session = Promise.await(client.startSession())
+    Promise.await(session.startTransaction())
+    try {
+      storage.remove({session})
+      Promise.await(session.commitTransaction())
+    } catch (e) {
+      Promise.await(session.abortTransaction())
+    } finally {
+      Promise.await(session.endSession())
+    }
+    test.equal(Storage.findOne(_id), undefined, 'The document should be removed')
+  });
+
+  Tinytest.add('Modules - Storage - Document remove with Mongo Transactions (Rollback)', function(test) {
+    const Storage = Class.get('PersistentStorage');
+    const Collection = Storage.getCollection()
+    const _id = Collection._makeNewID()
+    const expected = {
+      _id,
+      string: 'Some String'
+    }
+    const storage = new Storage(expected);
+    storage.save()
+
+    const { client } = MongoInternals.defaultRemoteCollectionDriver().mongo
+    session = Promise.await(client.startSession())
+    Promise.await(session.startTransaction())
+    try {
+      storage.remove({session})
+      throw new Meteor.Error(500, 'Throw error for testing purpose')
+      Promise.await(session.commitTransaction())
+    } catch (e) {
+      Promise.await(session.abortTransaction())
+    } finally {
+      Promise.await(session.endSession())
+    }
+    test.equal(Storage.findOne(_id, {
+        transform: null,
+      }), expected,
+      'Document does not have to be removed'
+    );
+  });
+
+}

--- a/test/modules/storage/init.js
+++ b/test/modules/storage/init.js
@@ -65,4 +65,18 @@ Tinytest.add('Modules - Storage - Init', function(test) {
       }
     }
   });
+
+  const PersistentStorages = new Mongo.Collection('persistent-storages');
+
+  const PersistentStorage = Class.create({
+    name: 'PersistentStorage',
+    collection: PersistentStorages,
+    fields: {
+      string: {
+        type: String,
+        optional: true
+      }
+    }
+  });
+
 });


### PR DESCRIPTION
Check please support for mongo transactions. Related to feature request #706 

```js
import Post from './post'
import User from './user'
import { MongoInternals } from 'meteor/mongo';

let post = Post.find(postQuery);
let user = User.find(userQuery);

post.userId = user._id;
user.posts.push(post);

const { client } = MongoInternals.defaultRemoteCollectionDriver().mongo;
const session = await client.startSession();
await session.startTransaction();
try {
  post.save({session});
  user.save({session});
  await session.commitTransaction();
} catch (e) {
  await session.abortTransaction();
} finally {
  session.endSession();
}
```